### PR TITLE
Add progress tracking and resume support

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
     pdf_directory: Path = Field(default=Path("./data/pdfs"), alias="PDF_DIRECTORY")
     features_file: Path = Field(default=Path("./data/features.xlsx"), alias="FEATURES_FILE")
     results_file: Path = Field(default=Path("./data/results.xlsx"), alias="RESULTS_FILE")
+    progress_file: Path = Field(default=Path("./data/progress.json"), alias="PROGRESS_FILE")
     chroma_db_path: Path = Field(default=Path("./chroma_db"), alias="CHROMA_DB_PATH")
     log_file: Path = Field(default=Path("./logs/extraction.log"), alias="LOG_FILE")
 
@@ -77,7 +78,7 @@ class Settings(BaseSettings):
 
         return path
 
-    @field_validator("results_file", "log_file", mode='before')
+    @field_validator("results_file", "log_file", "progress_file", mode='before')
     @classmethod
     def validate_and_create_path(cls, v: Any) -> Path:
         if isinstance(v, str):

--- a/progress_tracker.py
+++ b/progress_tracker.py
@@ -1,0 +1,127 @@
+"""Utilities for tracking paper processing progress with atomic persistence."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+
+class ProgressTracker:
+    """Manage loading and persisting paper processing progress."""
+
+    def __init__(self, progress_file: Path) -> None:
+        self.progress_file = progress_file
+        self.progress_file.parent.mkdir(parents=True, exist_ok=True)
+        self._logger = logging.getLogger(__name__)
+        self._progress: Dict[str, Dict[str, Any]] = {}
+        self.refresh()
+
+    def refresh(self) -> Dict[str, Dict[str, Any]]:
+        """Reload the progress file from disk."""
+        self._progress = self._load_progress()
+        return self._progress
+
+    def get_processed_papers(self) -> set[str]:
+        """Return the set of paper identifiers recorded in progress."""
+        return set(self._progress.keys())
+
+    def record(
+        self,
+        paper_id: str,
+        paper_name: str,
+        status: str,
+        details: Dict[str, Any] | None = None,
+    ) -> None:
+        """Persist the latest status for a paper using an atomic file replace."""
+        entry: Dict[str, Any] = {
+            "paper_name": paper_name,
+            "status": status,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        if details:
+            entry["details"] = details
+
+        self._progress[paper_id] = entry
+        self._write_progress(self._progress)
+
+    def remove(self, paper_id: str) -> None:
+        """Remove a paper from the progress tracking file."""
+        if paper_id not in self._progress:
+            return
+        del self._progress[paper_id]
+        self._write_progress(self._progress)
+
+    def _load_progress(self) -> Dict[str, Dict[str, Any]]:
+        if not self.progress_file.exists():
+            return {}
+
+        try:
+            with self.progress_file.open("r", encoding="utf-8") as file:
+                data = json.load(file)
+        except json.JSONDecodeError as exc:
+            self._logger.warning(
+                "Could not parse progress file %s: %s. Resetting progress state.",
+                self.progress_file,
+                exc,
+            )
+            return {}
+        except OSError as exc:
+            self._logger.warning(
+                "Failed to read progress file %s: %s. Assuming no progress.",
+                self.progress_file,
+                exc,
+            )
+            return {}
+
+        if not isinstance(data, dict):
+            self._logger.warning(
+                "Progress file %s contained unexpected data. Resetting progress state.",
+                self.progress_file,
+            )
+            return {}
+
+        # Ensure nested entries are dictionaries to avoid type issues later.
+        sanitized: Dict[str, Dict[str, Any]] = {}
+        for key, value in data.items():
+            if isinstance(value, dict):
+                sanitized[key] = value
+            else:
+                sanitized[key] = {"status": str(value)}
+        return sanitized
+
+    def _write_progress(self, data: Dict[str, Dict[str, Any]]) -> None:
+        self.progress_file.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", dir=str(self.progress_file.parent), delete=False
+            ) as tmp_file:
+                json.dump(data, tmp_file, indent=2, sort_keys=True)
+                tmp_file.flush()
+                os.fsync(tmp_file.fileno())
+                temp_path = Path(tmp_file.name)
+        except OSError as exc:
+            self._logger.error(
+                "Failed to write progress file %s: %s", self.progress_file, exc
+            )
+            return
+
+        try:
+            temp_path.replace(self.progress_file)
+        except OSError as exc:
+            self._logger.error(
+                "Failed to replace progress file %s: %s", self.progress_file, exc
+            )
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return
+
+        # Ensure in-memory cache stays aligned with disk state.
+        self._progress = data.copy()
+


### PR DESCRIPTION
## Summary
- add a configurable progress JSON file path to the application settings
- introduce a ProgressTracker utility that persists paper status updates atomically
- integrate the tracker with the batch pipeline to skip completed papers, honor --force, and refresh progress between batches

## Testing
- pytest *(fails: missing optional dependencies pandas and langchain_community)*

------
https://chatgpt.com/codex/tasks/task_e_68d6839138248326ac3507a62acac58d