### PR TITLE
Improve PDF processing resilience across agents

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,7 +54,11 @@ def _process_single_pdf(
     """Run the agent pipeline for a single PDF and return summary messages."""
     message_queue: Queue = Queue()
 
-    pdf_agent = PDFAgent(message_queue, [pdf_path])
+    pdf_agent = PDFAgent(
+        message_queue,
+        [pdf_path],
+        embedding_manager.pdf_processor,
+    )
     embedding_agent = EmbeddingAgent(message_queue, embedding_manager)
     extraction_agent = ExtractionAgent(message_queue, feature_extractor, fields)
     results_agent = ResultsAgent(message_queue, excel_handler, settings.results_file, field_names)

--- a/pdf_processor.py
+++ b/pdf_processor.py
@@ -4,7 +4,7 @@ Handle PDF text extraction and intelligent chunking using LangChain.
 
 from langchain_community.document_loaders import PDFPlumberLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from typing import List, Dict
+from typing import List, Optional
 from langchain_core.documents import Document
 import logging
 import hashlib
@@ -54,3 +54,22 @@ class PDFProcessor:
 
         logger.info(f"Created {len(chunks)} chunks for paper {paper_id}")
         return chunks
+
+    def extract_and_chunk_pdf(self, pdf_path: str, paper_id: str) -> Optional[List[Document]]:
+        """Extract a PDF and generate enriched chunks, returning ``None`` on failure."""
+
+        try:
+            documents = self.extract_text_from_pdf(pdf_path)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error(
+                "Error extracting text from %s: %s", pdf_path, exc, exc_info=True
+            )
+            return None
+
+        try:
+            return self.create_smart_chunks(documents, paper_id)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error(
+                "Error chunking extracted text for %s: %s", pdf_path, exc, exc_info=True
+            )
+            return None


### PR DESCRIPTION
## Summary
- add a unified `extract_and_chunk_pdf` helper to `PDFProcessor` with defensive logging
- reuse the helper in `PDFAgent` and `EmbeddingManager` so extraction failures surface cleanly
- expand unit tests for the PDF processor to cover the new helper

## Testing
- pytest *(fails: missing optional dependencies such as `pandas` and `langchain_community`)*

------
https://chatgpt.com/codex/tasks/task_e_68d686abd35c832691994b3383727056