### PR TITLE
Update Ollama integrations for latest LangChain packages

### DIFF
--- a/embedding_manager.py
+++ b/embedding_manager.py
@@ -2,11 +2,8 @@
 Manage ChromaDB collections and embeddings for each paper.
 """
 
-try:
-    from langchain_ollama import OllamaEmbeddings
-except ImportError:
-    from langchain_community.embeddings import OllamaEmbeddings
-from langchain_community.vectorstores import Chroma
+from langchain_ollama import OllamaEmbeddings
+from langchain_chroma import Chroma
 from typing import List, Optional
 from langchain_core.documents import Document
 from pathlib import Path
@@ -32,15 +29,23 @@ class EmbeddingManager:
             self.embedding_function = OllamaEmbeddings(
                 base_url="http://localhost:11434",  # Default Ollama URL
                 model=self.embedding_model_name,
-                show_progress=True,
             )
 
-            # Test the connection but don't crash if it fails
             try:
                 test_embedding = self.embedding_function.embed_query("test")
-                logger.info(f"Ollama embedding model loaded successfully! Embedding dimension: {len(test_embedding)}")
-            except Exception as e:
-                logger.warning(f"Could not connect to Ollama to test embedding model: {e}")
+                logger.info(
+                    "Ollama embedding model loaded successfully! Embedding dimension: %d",
+                    len(test_embedding),
+                )
+            except Exception as conn_error:
+                logger.error(
+                    "Failed to connect to the Ollama embedding service at %s: %s",
+                    "http://localhost:11434",
+                    conn_error,
+                )
+                raise RuntimeError(
+                    "Unable to connect to the Ollama embedding service. Ensure Ollama is running and accessible."
+                ) from conn_error
 
         except Exception as e:
             logger.error(f"Failed to initialize Ollama embeddings class: {e}")

--- a/feature_extractor.py
+++ b/feature_extractor.py
@@ -3,7 +3,7 @@ Core extraction logic combining semantic search and LLM calls.
 """
 
 from typing import Dict, List, Any
-from langchain_community.vectorstores import Chroma
+from langchain_chroma import Chroma
 from langchain_core.documents import Document
 import logging
 

--- a/llm_client.py
+++ b/llm_client.py
@@ -2,10 +2,11 @@
 Unified interface for Ollama and vLLM providers using LangChain.
 """
 
-from langchain_community.llms import Ollama, VLLM
+from langchain_ollama import OllamaLLM
+from langchain_vllm import VLLM
 from langchain.prompts import PromptTemplate
 from langchain_core.output_parsers import JsonOutputParser
-from langchain_core.pydantic_v1 import BaseModel, Field
+from pydantic import BaseModel, Field
 from typing import Optional, List, Dict, Any
 import logging
 from utils import retry_with_backoff
@@ -33,7 +34,7 @@ class LLMClient:
         }
 
         if provider == "ollama":
-            self.llm = Ollama(
+            self.llm = OllamaLLM(
                 base_url=base_url,
                 **common_params
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 langchain
-langchain-community>=0.0.20
+langchain-chroma>=0.1.0
+langchain-ollama>=0.1.0
+langchain-vllm>=0.1.0
 ollama>=0.1.7
 langgraph==0.0.26
 chromadb==0.4.22
@@ -12,10 +14,9 @@ python-dotenv==1.0.0
 tqdm==4.66.1
 requests==2.31.0
 numpy
-pydantic
+pydantic>=2.0.0
 tiktoken==0.5.2
 filelock==3.13.1
 pydantic-settings==2.1.0
 PyYAML==6.0.1
 langchain-huggingface
-langchain-ollama>=0.1.0

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -4,15 +4,15 @@ from llm_client import LLMClient, FeatureExtractionOutput
 
 class TestLLMClient(unittest.TestCase):
 
-    @patch('llm_client.Ollama')
-    def test_llm_client_initialization(self, mock_ollama):
+    @patch('llm_client.OllamaLLM')
+    def test_llm_client_initialization(self, mock_ollama_llm):
         # Test if the client initializes correctly
         client = LLMClient(provider="ollama", base_url="http://localhost:11434", model_name="test-model", temperature=0.1, max_tokens=100)
         self.assertIsNotNone(client.llm)
-        mock_ollama.assert_called_once()
+        mock_ollama_llm.assert_called_once()
 
-    @patch('llm_client.Ollama')
-    def test_extract_feature_mocked(self, mock_ollama):
+    @patch('llm_client.OllamaLLM')
+    def test_extract_feature_mocked(self, mock_ollama_llm):
         # Setup client
         client = LLMClient(provider="ollama", base_url="http://localhost:11434", model_name="test-model", temperature=0.1, max_tokens=100)
 
@@ -33,7 +33,7 @@ class TestLLMClient(unittest.TestCase):
 
         mock_prompt_llm_chain = MagicMock()
 
-        # client.llm is already a mock of Ollama
+        # client.llm is already a mock of OllamaLLM
         # client.output_parser is a real object. We can leave it or mock it.
 
         # Let's mock the two __or__ calls


### PR DESCRIPTION
## Summary
- replace deprecated langchain-community imports with the supported langchain-ollama and langchain-chroma packages
- harden Ollama embedding initialization and migrate structured output models to Pydantic v2
- refresh dependency pins to align with the current LangChain ecosystem

## Testing
- pytest *(fails: missing pandas and langchain integration packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d68a239f4c83269e3893cc24d21fa5